### PR TITLE
Possible Fix for test_dem2pts failure

### DIFF
--- a/anuga/__init__.py
+++ b/anuga/__init__.py
@@ -22,9 +22,9 @@
 
 __version__ = '2.0'
 
-__svn_revision__ = filter(str.isdigit, "$Revision: 9726 $")
+__svn_revision__ = filter(str.isdigit, "$Revision: 9733 $")
 
-__svn_revision_date__ = "$Date: 2015-04-27 13:36:20 +1000 (Mon, 27 Apr 2015) $"[7:-1]
+__svn_revision_date__ = "$Date: 2015-05-04 12:09:38 +1000 (Mon, 04 May 2015) $"[7:-1]
 
 
 # We first need to detect if we're being called as part of the anuga setup

--- a/anuga/file_conversion/dem2pts.py
+++ b/anuga/file_conversion/dem2pts.py
@@ -152,7 +152,7 @@ def _dem2pts(name_in, name_out=None, verbose=False,
     outfile.ncols = ncols
     outfile.nrows = nrows
 
-    dem_elevation_r = num.reshape(dem_elevation, (nrows, ncols))
+    #dem_elevation_r = num.reshape(dem_elevation, (nrows, ncols))
     totalnopoints = nrows*ncols
 
 


### PR DESCRIPTION
Duncan has been getting an error when using an environment with numpy 1.9


ERROR: test_dem2pts_bounding_box_v2 (__main__.Test_Dem2Pts)
Test conversion from dem in ascii format to native NetCDF format

Traceback (most recent call last):
  File "test_dem2pts.py", line 92, in test_dem2pts_bounding_box_v2
    verbose=False)
  File "/nas/mnh/georisk_models/inundation/sandpits/dgray/anuga_core/anuga/file_conversion/dem2pts.py", line 50, in dem2pts
    result = apply(_dem2pts, [name_in], kwargs)
  File "/nas/mnh/georisk_models/inundation/sandpits/dgray/anuga_core/anuga/file_conversion/dem2pts.py", line 155, in _dem2pts
   dem_elevation_r = num.reshape(dem_elevation, (nrows, ncols))
  File "/scratch/anaconda/lib/python2.7/site-packages/numpy/core/fromnumeric.py", line 220, in reshape
    return _wrapit(a, 'reshape', newshape, order=order)
  File "/scratch/anaconda/lib/python2.7/site-packages/numpy/core/fromnumeric.py", line 45, in _wrapit
    result = getattr(asarray(obj), method)(*args, **kwds)
  File "/scratch/anaconda/lib/python2.7/site-packages/numpy/core/numeric.py", line 462, in asarray
    return array(a, dtype, copy=False, order=order)
IOError: Index exceeds dimension bound

It might have to do with dem_elevation not being a numpy array. So have removed this problem