### PR TITLE
Avoid creating vertex indices when using DE

### DIFF
--- a/anuga/operators/erosion_operators.py
+++ b/anuga/operators/erosion_operators.py
@@ -73,13 +73,15 @@ class Erosion_operator(Operator, Region):
         # doesn't fixup the relationship between
         # bed and stage vertex values in dry region
         #------------------------------------------
-        self.domain.optimise_dry_cells = 0
+        if not self.domain.get_using_discontinuous_elevation():
+            self.domain.optimise_dry_cells = 0
 
         #-----------------------------------------
         # Extra structures to support maintaining
         # continuity of elevation
         #-----------------------------------------
-        self.setup_node_structures()
+        if not self.domain.get_using_discontinuous_elevation():
+            self.setup_node_structures()
 
         #-----------------------------------------
         # Some extras for reporting


### PR DESCRIPTION
This is a second attempt at ensuring that erosion operators only work with centroid values if using DE algorithms.