### PR TITLE
De2 mass protection

### DIFF
--- a/anuga/abstract_2d_finite_volumes/generic_domain.py
+++ b/anuga/abstract_2d_finite_volumes/generic_domain.py
@@ -1916,8 +1916,16 @@ class Generic_Domain:
         ######
 
         # Combine steps
-        self.saxpy_conserved_quantities(2.0/3.0, 1.0/3.0)
-
+        
+        # This causes a roundoff error that created negative water heights
+        #self.saxpy_conserved_quantities(2.0/3.0, 1.0/3.0)
+        
+        # So do this instead!
+        self.saxpy_conserved_quantities(2.0, 1.0)
+        for name in self.conserved_quantities:
+            Q = self.quantities[name]
+            Q.centroid_values[:] = Q.centroid_values/3.0
+            
 
         # Update special conditions
         #self.update_special_conditions()

--- a/anuga/shallow_water/shallow_water_domain.py
+++ b/anuga/shallow_water/shallow_water_domain.py
@@ -2060,6 +2060,7 @@ class Domain(Generic_Domain):
 
             from swDE1_domain_ext import protect_new
             
+            
             mass_error = protect_new(self)
 
 #             # shortcuts
@@ -2409,34 +2410,34 @@ class Domain(Generic_Domain):
 
 
 
-    def evolve_one_euler_step(self, yieldstep, finaltime):
-        """One Euler Time Step
-        Q^{n+1} = E(h) Q^n
-
-        Does not assume that centroid values have been extrapolated to vertices and edges
-        """
-            
-        # From centroid values calculate edge and vertex values
-        self.distribute_to_vertices_and_edges()
-            
-        # Apply boundary conditions
-        self.update_boundary()
-        
-        # Compute fluxes across each element edge
-        self.compute_fluxes()
-
-        # Compute forcing terms
-        self.compute_forcing_terms()
-
-        # Update timestep to fit yieldstep and finaltime
-        self.update_timestep(yieldstep, finaltime)
-
-        if self.max_flux_update_frequency is not 1:
-            # Update flux_update_frequency using the new timestep
-            self.compute_flux_update_frequency()
-
-        # Update conserved quantities
-        self.update_conserved_quantities()
+#     def evolve_one_euler_step(self, yieldstep, finaltime):
+#         """One Euler Time Step
+#         Q^{n+1} = E(h) Q^n
+# 
+#         Does not assume that centroid values have been extrapolated to vertices and edges
+#         """
+#             
+#         # From centroid values calculate edge and vertex values
+#         self.distribute_to_vertices_and_edges()
+#             
+#         # Apply boundary conditions
+#         self.update_boundary()
+#         
+#         # Compute fluxes across each element edge
+#         self.compute_fluxes()
+# 
+#         # Compute forcing terms
+#         self.compute_forcing_terms()
+# 
+#         # Update timestep to fit yieldstep and finaltime
+#         self.update_timestep(yieldstep, finaltime)
+# 
+#         if self.max_flux_update_frequency is not 1:
+#             # Update flux_update_frequency using the new timestep
+#             self.compute_flux_update_frequency()
+# 
+#         # Update conserved quantities
+#         self.update_conserved_quantities()
     
         
         

--- a/anuga/shallow_water/shallow_water_domain.py
+++ b/anuga/shallow_water/shallow_water_domain.py
@@ -2407,41 +2407,7 @@ class Domain(Generic_Domain):
 
             # Pass control on to outer loop for more specific actions
             yield(t)
-
-
-
-#     def evolve_one_euler_step(self, yieldstep, finaltime):
-#         """One Euler Time Step
-#         Q^{n+1} = E(h) Q^n
-# 
-#         Does not assume that centroid values have been extrapolated to vertices and edges
-#         """
-#             
-#         # From centroid values calculate edge and vertex values
-#         self.distribute_to_vertices_and_edges()
-#             
-#         # Apply boundary conditions
-#         self.update_boundary()
-#         
-#         # Compute fluxes across each element edge
-#         self.compute_fluxes()
-# 
-#         # Compute forcing terms
-#         self.compute_forcing_terms()
-# 
-#         # Update timestep to fit yieldstep and finaltime
-#         self.update_timestep(yieldstep, finaltime)
-# 
-#         if self.max_flux_update_frequency is not 1:
-#             # Update flux_update_frequency using the new timestep
-#             self.compute_flux_update_frequency()
-# 
-#         # Update conserved quantities
-#         self.update_conserved_quantities()
-    
-        
-        
-        
+     
 
     def initialise_storage(self):
         """Create and initialise self.writer object for storing data.


### PR DESCRIPTION
There was a problem using DE2, where the update of areas with zero depth of water would actually create negative water depths if using DE2. 

This came down to a calculation in DE2 of the form 

Q_new  = 2/3 Q_1 + 1/3 Q_old

This was changed to

Q_new = 1/3 ( 2 Q_1 +  Q_old),

which seems to have alleviated the problem.