### PR TITLE
Issue #72 fix starttime bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,13 @@ wave_atten.png
 *.so
 _configtest.c
 
+
+# Example tmp files #
+#####################
+
+examples/checkpointing/CHECKPOINTS
+
+
 # Packages #
 ############
 # it's better to unpack these files and commit the raw source

--- a/anuga/abstract_2d_finite_volumes/tests/test_gauge.py
+++ b/anuga/abstract_2d_finite_volumes/tests/test_gauge.py
@@ -79,7 +79,7 @@ class Test_Gauge(unittest.TestCase):
         self.sww.store_timestep()
         self.domain.set_quantity('stage', stage) # This is automatically limited
         # so it will not be less than the elevation
-        self.domain.set_time(self.domain.get_time()-self.domain.starttime+timestep)
+        self.domain.set_time(self.domain.get_time()+timestep)
         self.sww.store_timestep()
         
         
@@ -261,7 +261,7 @@ point2, 0.5, 2.0, 9.0\n")
                             use_cache=False)
 
 #        point1_answers_array = [[0.0,1.0,-5.0,3.0,4.0], [2.0,10.0,-5.0,3.0,4.0]]
-        point1_answers_array = [[2.0, 0.0005555555555555556, 1.0, 4.0, -3.0, 3.0, 4.0], [3.0, 0.0008333333333333334, 10.0, 13.0, -3.0, 3.0, 4.0] ]
+        point1_answers_array = [[1.0, 0.0002777777777777778, 1.0, 4.0, -3.0, 3.0, 4.0], [3.0, 0.0008333333333333334, 10.0, 13.0, -3.0, 3.0, 4.0] ]
         point1_filename = 'gauge_point1.csv'
         point1_handle = file(point1_filename)
         point1_reader = reader(point1_handle)
@@ -275,7 +275,7 @@ point2, 0.5, 2.0, 9.0\n")
             #print 'assert line',line[i],'answer',point1_answers_array[i]
             assert num.allclose(line[i], point1_answers_array[i])
 
-        point2_answers_array = [[2.0, 0.0005555555555555556, 1.0, 3.416666666666667, -2.416666666666667, 3.0, 4.0], [3.0, 0.0008333333333333334, 10.000000000000002, 12.416666666666668, -2.416666666666667, 3.0, 4.0]]
+        point2_answers_array = [[1.0, 0.0002777777777777778, 1.0, 3.416666666666667, -2.416666666666667, 3.0, 4.0], [3.0, 0.0008333333333333334, 10.000000000000002, 12.416666666666668, -2.416666666666667, 3.0, 4.0]]
         point2_filename = 'gauge_point2.csv' 
         point2_handle = file(point2_filename)
         point2_reader = reader(point2_handle)
@@ -542,9 +542,9 @@ point2, 0.5, 2.0\n")
         # clean up
         point1_handle.close()
         point2_handle.close() 
-        os.remove(points_file)
-        os.remove(point1_filename)
-        os.remove(point2_filename)       
+        #os.remove(points_file)
+        #os.remove(point1_filename)
+        #os.remove(point2_filename)       
 
         #remove second swwfile not removed by tearDown
         os.remove(basename+".sww")
@@ -553,7 +553,7 @@ point2, 0.5, 2.0\n")
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_Gauge, 'test_')
+    suite = unittest.makeSuite(Test_Gauge, 'test')
 #    runner = unittest.TextTestRunner(verbosity=2)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/operators/tests/test_rate_operators.py
+++ b/anuga/operators/tests/test_rate_operators.py
@@ -322,8 +322,12 @@ class Test_rate_operators(unittest.TestCase):
         indices = [0,1,3]
 
 
-        rate = file_function('test_file_function.tms', quantities=['Attribute1'])
+        rate = file_function(filename + '.tms', quantities=['Attribute1'])
+        
 
+        # Make starttime of domain consistent with tms file starttime
+        domain.set_starttime(rate.starttime)
+                    
         factor = 1000.0
         default_rate= 17.7
 
@@ -332,10 +336,11 @@ class Test_rate_operators(unittest.TestCase):
 
 
         # Apply Operator
-        domain.set_starttime(360.0)
+        domain.set_time(360.0)
         domain.timestep = 1.0
 
         operator()
+
 
 
         d = domain.get_time()**2 * factor + 1.0
@@ -354,7 +359,7 @@ class Test_rate_operators(unittest.TestCase):
         assert num.allclose(domain.fractional_step_volume_integral, ((d-1.)*domain.areas[indices]).sum())
 
 
-        domain.set_starttime(-10.0)
+        domain.set_time(-10.0)
         domain.timestep = 1.0
 
         try:
@@ -365,7 +370,7 @@ class Test_rate_operators(unittest.TestCase):
             raise Exception('Should have raised an exception, time too early')
 
 
-        domain.set_starttime(1300.0)
+        domain.set_time(1300.0)
         domain.timestep = 1.0
 
         operator()
@@ -382,6 +387,8 @@ class Test_rate_operators(unittest.TestCase):
         assert num.allclose(domain.quantities['xmomentum'].centroid_values, 0.0)
         assert num.allclose(domain.quantities['ymomentum'].centroid_values, 0.0)
         assert num.allclose(domain.fractional_step_volume_integral, ((d-1.)*domain.areas[indices]).sum())
+
+
 
 
     def test_rate_operator_functions_rate_default_rate(self):

--- a/anuga/shallow_water/forcing.py
+++ b/anuga/shallow_water/forcing.py
@@ -271,6 +271,7 @@ class General_forcing:
                  radius=None,
                  polygon=None,
                  default_rate=None,
+                 relative_time=True,
                  verbose=False):
 
         from math import pi, cos, sin
@@ -294,6 +295,7 @@ class General_forcing:
         self.radius = radius
         self.polygon = polygon
         self.verbose = verbose
+        self.relative_time = relative_time
         self.value = 0.0    # Can be used to remember value at
                             # previous timestep in order to obtain rate
 
@@ -407,7 +409,7 @@ class General_forcing:
         """Apply inflow function at time specified in domain, update stage"""
 
         # Call virtual method allowing local modifications
-        t = domain.get_time()
+        t = domain.get_time(relative=self.relative_time)
         try:
             rate = self.update_rate(t)
         except Modeltime_too_early, e:
@@ -553,6 +555,7 @@ class Rainfall(General_forcing):
                  radius=None,
                  polygon=None,
                  default_rate=None,
+                 relative_time=True,
                  verbose=False):
 
         # Converting mm/s to m/s to apply in ANUGA)
@@ -579,6 +582,7 @@ class Rainfall(General_forcing):
                                  radius=radius,
                                  polygon=polygon,
                                  default_rate=default_rain,
+                                 relative_time=relative_time,
                                  verbose=verbose)
 
 
@@ -637,6 +641,7 @@ class Inflow(General_forcing):
                  radius=None,
                  polygon=None,
                  default_rate=None,
+                 relative_time=True,
                  verbose=False):
         """Create an instance of the class
 
@@ -658,6 +663,7 @@ class Inflow(General_forcing):
                                  radius=radius,
                                  polygon=polygon,
                                  default_rate=default_rate,
+                                 relative_time=relative_time,
                                  verbose=verbose)
 
     def update_rate(self, t):

--- a/anuga/shallow_water/shallow_water_domain.py
+++ b/anuga/shallow_water/shallow_water_domain.py
@@ -2360,7 +2360,7 @@ class Domain(Generic_Domain):
         # evolve loop but we do it here to ensure the values are ok for storage.
         self.distribute_to_vertices_and_edges()
 
-        if self.store is True and self.get_time() == self.get_starttime():
+        if self.store is True and self.get_time() == 0.0:
             self.initialise_storage()
             
         if self.get_time() >= finaltime: yield

--- a/anuga/utilities/plot_utils.py
+++ b/anuga/utilities/plot_utils.py
@@ -152,7 +152,7 @@ class get_output:
         self.x, self.y, self.time, self.vols, self.stage, \
                 self.height, self.elev, self.friction, self.xmom, self.ymom, \
                 self.xvel, self.yvel, self.vel, self.minimum_allowed_height,\
-                self.xllcorner, self.yllcorner, self.timeSlices = \
+                self.xllcorner, self.yllcorner, self.timeSlices, self.starttime = \
                 _read_output(filename, minimum_allowed_height,copy.copy(timeSlices))
         self.filename = filename
         self.verbose = verbose
@@ -253,6 +253,7 @@ def _read_output(filename, minimum_allowed_height, timeSlices):
     # Get lower-left
     xllcorner=fid.xllcorner
     yllcorner=fid.yllcorner
+    starttime=fid.starttime
 
     # Read variables
     x=fid.variables['x'][:]
@@ -320,7 +321,7 @@ def _read_output(filename, minimum_allowed_height, timeSlices):
     fid.close()
 
     return x, y, time, vols, stage, height, elev, friction, xmom, ymom,\
-           xvel, yvel, vel, minimum_allowed_height, xllcorner,yllcorner, inds
+           xvel, yvel, vel, minimum_allowed_height, xllcorner,yllcorner, inds, starttime
 
 ######################################################################################
 

--- a/validation_tests/case_studies/patong/run_model.py
+++ b/validation_tests/case_studies/patong/run_model.py
@@ -277,12 +277,6 @@ domain.set_boundary({'back': Br,
 t0 = time.time()
 
 
-## Jump up to time 400 sec to cover missing boundary data before 302 sec
-for t in domain.evolve(yieldstep=400, finaltime=400):
-    log.critical(domain.timestepping_statistics())
-#    log.critical(domain.boundary_statistics(tags='ocean'))
-
-
 import time
 
 # Start detailed model


### PR DESCRIPTION
Changed the evolve code to go back to using relative time. At some time it had been changed so that domain.time was absolute time. This caused problems with calculating sts boundaries and writing out gauge data. 