### PR TITLE
Towradgi case study didnt work on windows without pypar

### DIFF
--- a/validation_tests/case_studies/towradgi/Towradgi_historic_flood.py
+++ b/validation_tests/case_studies/towradgi/Towradgi_historic_flood.py
@@ -36,8 +36,8 @@ from anuga import Inlet_operator
 # PARALLEL INTERFACE
 #------------------------------------------------------------------------------
 
-from anuga import distribute, myid, numprocs, finalize,barrier
-from anuga.parallel.parallel_operator_factory import Inlet_operator, Boyd_box_operator
+from anuga import distribute, myid, numprocs, finalize, barrier
+from anuga import Inlet_operator, Boyd_box_operator
 from anuga import Rate_operator
 
 


### PR DESCRIPTION
The script Towradgi_historic_flood.py has an old import which failed if pypar was not installed. Changed import of Inlet_operator