### PR TITLE
Fixed problem with yield of finaltime when using duration in evolve

### DIFF
--- a/anuga/abstract_2d_finite_volumes/generic_domain.py
+++ b/anuga/abstract_2d_finite_volumes/generic_domain.py
@@ -1563,12 +1563,14 @@ class Generic_Domain:
         self.evolved_called = True
 
         # We assume evolve has already been called so we should now
-        # set starttime to match actual time
+        # set evolve_starttime to match actual time
         
         if skip_initial_step:
             self.set_evolve_starttime(self.get_time())
 
-
+        #import pdb
+        #pdb.set_trace()
+        
         # This can happen on the first call to evolve
         if self.get_time() != self.get_evolve_starttime():
             self.set_time(self.get_evolve_starttime())
@@ -1628,8 +1630,10 @@ class Generic_Domain:
             #==========================================  
             self.distribute_to_vertices_and_edges()
             self.update_boundary()
-
+            
             yield(self.get_time())      # Yield initial values
+            
+            
 
         while True:
 

--- a/anuga/shallow_water/shallow_water_domain.py
+++ b/anuga/shallow_water/shallow_water_domain.py
@@ -2363,7 +2363,6 @@ class Domain(Generic_Domain):
         if self.store is True and self.get_time() == 0.0:
             self.initialise_storage()
             
-        if self.get_time() >= finaltime: yield
 
         # Call basic machinery from parent class
         for t in self._evolve_base(yieldstep=yieldstep,

--- a/anuga/shallow_water/tests/test_shallow_water_domain.py
+++ b/anuga/shallow_water/tests/test_shallow_water_domain.py
@@ -4325,6 +4325,75 @@ class Test_Shallow_Water(unittest.TestCase):
             print ('Fy'.ljust(qwidth), Fy.centroid_values[k],
                    Fy.vertex_values[k,:], Fy.edge_values[k,:])
 
+    def test_evolve_finaltime(self):
+        """Test evolve with finaltime set
+        """
+
+        from anuga import rectangular_cross_domain
+
+        # Create basic mesh
+        domain = rectangular_cross_domain(6, 6)
+        domain.set_name('evolve_finaltime')
+        
+        # IC
+        def x_slope(x, y):
+            return x/3
+
+        domain.set_quantity('elevation', 0)
+        domain.set_quantity('friction', 0)
+        domain.set_quantity('stage', x_slope)
+
+        # Boundary conditions (reflective everywhere)
+        Br = Reflective_boundary(domain)
+        domain.set_boundary({'left': Br, 'right': Br, 'top': Br, 'bottom': Br})
+
+        domain.check_integrity()
+
+        # Evolution 
+        # Test that t is a float
+        tt = 0.0
+        for t in domain.evolve(yieldstep=0.05, finaltime=5.0):
+            tt += t
+           
+        assert num.allclose(tt,252.5)
+
+
+        os.remove(domain.get_name() + '.sww')
+
+    def test_evolve_duration(self):
+        """Test evolve with finaltime set
+        """
+
+        from anuga import rectangular_cross_domain
+
+        # Create basic mesh
+        domain = rectangular_cross_domain(6, 6)
+        domain.set_name('evolve_duration')
+        
+        # IC
+        def x_slope(x, y):
+            return x/3
+
+        domain.set_quantity('elevation', 0)
+        domain.set_quantity('friction', 0)
+        domain.set_quantity('stage', x_slope)
+
+        # Boundary conditions (reflective everywhere)
+        Br = Reflective_boundary(domain)
+        domain.set_boundary({'left': Br, 'right': Br, 'top': Br, 'bottom': Br})
+
+        domain.check_integrity()
+
+        # Evolution
+        # Test that t is a float
+        tt = 0.0
+        for t in domain.evolve(yieldstep=0.05, duration=5.0):
+            tt += t
+        
+        assert num.allclose(tt,252.5)
+
+        os.remove(domain.get_name() + '.sww')
+
     def test_conservation_1(self):
         """Test that stage is conserved globally
 


### PR DESCRIPTION
Set up unit test to pick up Ted's bug when using t from evolve loop when duration is set and finaltime is not set. finaltime then becomes None and this value was yielded, to cause error