### PR TITLE
Added possibility to update_ghosts for other quantities

### DIFF
--- a/anuga/abstract_2d_finite_volumes/generic_domain.py
+++ b/anuga/abstract_2d_finite_volumes/generic_domain.py
@@ -2247,11 +2247,14 @@ class Generic_Domain:
             # Where is Q.semi_implicit_update reset?
             # It is reset in quantity_ext.c
 
-    def update_ghosts(self):
+    def update_ghosts(self, quantities=None):
         # We must send the information from the full cells and
         # receive the information for the ghost cells
         # We have a list with ghosts expecting updates
-
+        
+        if quantities is None:
+            quantities = self.conserved_quantities
+            
         #Update of ghost cells
         iproc = self.processor
         if self.full_send_dict.has_key(iproc):
@@ -2262,7 +2265,7 @@ class Generic_Domain:
             # now store ghost as local id, global id, value
             Idg = self.ghost_recv_dict[iproc][0]
 
-            for i, q in enumerate(self.conserved_quantities):
+            for i, q in enumerate(quantities):
                 Q_cv =  self.quantities[q].centroid_values
                 num.put(Q_cv, Idg, num.take(Q_cv, Idf, axis=0))
 

--- a/anuga/parallel/parallel_generic_communications.py
+++ b/anuga/parallel/parallel_generic_communications.py
@@ -133,7 +133,7 @@ def communicate_ghosts_blocking(domain):
 
 
 
-def communicate_ghosts_asynchronous(domain):
+def communicate_ghosts_asynchronous(domain, quantities=None):
 
     # We must send the information from the full cells and
     # receive the information for the ghost cells
@@ -144,6 +144,9 @@ def communicate_ghosts_asynchronous(domain):
     import numpy as num
     import time
     t0 = time.time()
+    
+    if quantities is None:
+        quantities = domain.conserved_quantities
 
     # update of non-local ghost cells by copying full cell data into the
     # Xout buffer arrays
@@ -155,22 +158,14 @@ def communicate_ghosts_asynchronous(domain):
         Idf  = domain.full_send_dict[send_proc][0]
         Xout = domain.full_send_dict[send_proc][2]
 
-        for i, q in enumerate(domain.conserved_quantities):
+        for i, q in enumerate(quantities):
             #print 'Store send data',i,q
             Q_cv =  domain.quantities[q].centroid_values
             Xout[:,i] = num.take(Q_cv, Idf)
 
 
 
-#    from pprint import pprint
-#
-#    if pypar.rank() == 0:
-#        print 'Before commun 0'
-#        pprint(domain.full_send_dict)
-#
-#    if pypar.rank() == 1:
-#        print 'Before commun 1'
-#        pprint(domain.full_send_dict)
+
 
 
     # Do all the comuunication using isend/irecv via the buffers in the
@@ -196,7 +191,7 @@ def communicate_ghosts_asynchronous(domain):
         #print recv_proc
         #print X
 
-        for i, q in enumerate(domain.conserved_quantities):
+        for i, q in enumerate(quantities):
             #print 'Read receive data',i,q
             Q_cv =  domain.quantities[q].centroid_values
             num.put(Q_cv, Idg, X[:,i])

--- a/anuga/parallel/parallel_shallow_water.py
+++ b/anuga/parallel/parallel_shallow_water.py
@@ -135,12 +135,12 @@ class Parallel_domain(Domain):
 
 
 
-    def update_ghosts(self):
+    def update_ghosts(self, quantities=None):
         """We must send the information from the full cells and
         receive the information for the ghost cells
         """
             
-        generic_comms.communicate_ghosts_asynchronous(self)
+        generic_comms.communicate_ghosts_asynchronous(self, quantities)
         #generic_comms.communicate_ghosts_blocking(self)
 
     def apply_fractional_steps(self):


### PR DESCRIPTION
Setup update_ghosts so that it can be used to update arbitrary sets of quantities (actually up to 3 quantities as the communication buffer is just set to update stage, x and y momentum). 

For instance to update the elevation and stage (such as when applying an operator) use the quantities argument i.e. 

domain.update_ghosts(quantities = ['elevation', 'stage'])]