### PR TITLE
Prevent installation of MKL

### DIFF
--- a/tools/install_conda.sh
+++ b/tools/install_conda.sh
@@ -49,7 +49,7 @@ conda update --yes conda
 
 # Configure the conda environment and put it in the path using the
 # provided versions
-conda create -n anuga_env --yes python=$PYTHON_VERSION pip numpy scipy netcdf4 \
+conda create -n anuga_env --yes python=$PYTHON_VERSION pip nomkl numpy scipy netcdf4 \
     nose matplotlib
 source activate anuga_env
 


### PR DESCRIPTION
As a quick fix for #132, this will stop installation of MKL with conda-numpy which causes segfaults due to name clash with ``dcopy``