### PR TITLE
Updated to latest pymetis.

### DIFF
--- a/anuga/parallel/distribute_mesh.py
+++ b/anuga/parallel/distribute_mesh.py
@@ -122,7 +122,9 @@ def reorder_new(quantities, epart_order, proc_sum):
 #path.append('..' + sep + 'pymetis')
 
 try:
-    from anuga.pymetis.metis_ext import partMeshNodal
+#    from anuga.pymetis.metis_ext import partMeshNodal
+    import pymetis
+    from sets import Set
 except ImportError:
     print "***************************************************"
     print "         Metis is probably not compiled."
@@ -160,26 +162,34 @@ def pmesh_divide_metis_helper(domain, n_procs):
     
     n_tri = len(domain.triangles)
     if n_procs != 1: #Because metis chokes on it...
-        n_vert = domain.get_number_of_nodes()
-        t_list = domain.triangles.copy()
-        t_list = num.reshape(t_list, (-1,))
-    
-        # The 1 here is for triangular mesh elements.
-        # FIXME: Should update to Metis 5
-        edgecut, epart, npart = partMeshNodal(n_tri, n_vert, t_list, 1, n_procs)
-        # print edgecut
-        # print npart
-        #print epart
-        del edgecut
-        del npart
+    #    n_vert = domain.get_number_of_nodes()
+    #    t_list2 = domain.triangles.copy()
+    #    t_list = num.reshape(t_list2, (-1,))
+
+	# build adjacency list
+	# neighbours uses negative integer-indices to denote boudary edges.
+	# pymetis totally cant handle that, so we have to delete these.
+	neigh = domain.neighbours.tolist()
+	for i in xrange(len(neigh)):
+		if neigh[i][2] < 0:
+			del neigh[i][2]
+		if neigh[i][1] < 0:
+			del neigh[i][1]
+		if neigh[i][0] < 0:
+			del neigh[i][0]
+		
+	cutcount,partvert = pymetis.part_graph(n_procs,neigh)
+
+	#print "cutcount: ",cutcount
+	#print "partvert: ",len(partvert)
+	epart = partvert
 
         # Sometimes (usu. on x86_64), partMeshNodal returns an array of zero
         # dimensional arrays. Correct this.
+        # TODO: Not sure if this can still happen with metis 5
         if type(epart[0]) == num.ndarray:
             epart_new = num.zeros(len(epart), num.int)
             epart_new[:] = epart[:][0]
-#            for i in xrange(len(epart)):
-#                epart_new[i] = epart[i][0]
             epart = epart_new
             del epart_new
 

--- a/anuga/setup.py
+++ b/anuga/setup.py
@@ -26,7 +26,6 @@ def configuration(parent_package='',top_path=None):
     config.add_subpackage('operators')
     config.add_subpackage('parallel')
     config.add_subpackage('pmesh')
-    config.add_subpackage('pymetis')
     config.add_subpackage('shallow_water')
     config.add_subpackage('structures')
     config.add_subpackage('tsunami_source')

--- a/tools/install_conda.sh
+++ b/tools/install_conda.sh
@@ -57,7 +57,7 @@ conda update --yes conda
 
 # Configure the conda environment and put it in the path using the
 # provided versions
-conda create -n anuga_env -c conda-forge --yes python=$PYTHON_VERSION pip numpy scipy netcdf4 nose matplotlib gdal
+conda create -n anuga_env -c conda-forge --yes python=$PYTHON_VERSION pip numpy scipy netcdf4 nose matplotlib gdal pymetis
  
 
 source activate anuga_env

--- a/tools/install_conda_macos.sh
+++ b/tools/install_conda_macos.sh
@@ -38,7 +38,7 @@ conda update --yes conda
 # provided versions
 
 conda create -n anuga_env -c conda-forge --yes python=$PYTHON_VERSION pip numpy scipy netcdf4 \
-    nose matplotlib gdal
+    nose matplotlib gdal pymetis
 
 source activate anuga_env
 

--- a/tools/install_conda_macos.sh
+++ b/tools/install_conda_macos.sh
@@ -24,6 +24,12 @@ pushd pypar;
 python setup.py install;
 popd;
 
+# Install pymetis
+git clone https://github.com/inducer/pymetis.git;
+pushd pymetis;
+python setup.py install;
+popd;
+
 # Install miniconda
 wget https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh -O miniconda.sh ;
 
@@ -38,7 +44,7 @@ conda update --yes conda
 # provided versions
 
 conda create -n anuga_env -c conda-forge --yes python=$PYTHON_VERSION pip numpy scipy netcdf4 \
-    nose matplotlib gdal pymetis
+    nose matplotlib gdal
 
 source activate anuga_env
 

--- a/tools/install_ubuntu.sh
+++ b/tools/install_ubuntu.sh
@@ -67,6 +67,11 @@ echo "|  Using pip to install pyproj                  |"
 echo "+===============================================+"
 sudo pip install -q pyproj
 
+echo "+===============================================+"
+echo "|  Using pip to install pymetis                 |"
+echo "+===============================================+"
+sudo pip install -q pymetis
+
     
 ##########################################################
 # Setup for various versions of MPI


### PR DESCRIPTION
Updated to latest pymetis, which uses metis 5. Including our own version of pymetis with anuga should not be necessary anymore. Installers are not yet updated to reflect that. And pymetis has not yet been removed from the tree.