### PR TITLE
Added missing parameters to sub __init__ for parallel_internal_boundary_operator.py

### DIFF
--- a/anuga/parallel/parallel_internal_boundary_operator.py
+++ b/anuga/parallel/parallel_internal_boundary_operator.py
@@ -65,6 +65,8 @@ class Parallel_Internal_boundary_operator(Parallel_Structure_operator):
                                           diameter= None,
                                           apron=apron,
                                           manning=None,
+                                          blockage=None,#
+                                          barrels=None,#
                                           enquiry_gap=enquiry_gap,
                                           use_momentum_jet=use_momentum_jet,
                                           zero_outflow_momentum=zero_outflow_momentum,


### PR DESCRIPTION
Came across this while adding pumping-stations to my project. 
Call to Parallel_Structure_operator.__init__ was missing 2 (unused) parameters.