### PR TITLE
small fix for test_csv2sts.py on debian

### DIFF
--- a/anuga/file_conversion/tests/test_csv2sts.py
+++ b/anuga/file_conversion/tests/test_csv2sts.py
@@ -86,7 +86,7 @@ class Test_csv2sts(unittest.TestCase):
 
         path = get_pathname_from_package( 'anuga.file_conversion' )
         
-        cmd = 'python ' + os.path.join( path, 'csv2sts.py') + ' --latitude ' 
+        cmd = sys.executable + ' ' + os.path.join( path, 'csv2sts.py') + ' --latitude ' 
         cmd += '%s --lon %s %s %s' % (str(lat), str(lon), testfile_csv, sts_out)
         
         os.system(cmd)


### PR DESCRIPTION
Test fails because hardcoded python executable name does not exist on some versions of debian.  Use sys.executable instead to use the full path to the currently used interpreter.