### PR TITLE
Fix NameError in util.get_gauges_from_file

### DIFF
--- a/anuga/abstract_2d_finite_volumes/tests/test_util.py
+++ b/anuga/abstract_2d_finite_volumes/tests/test_util.py
@@ -1598,7 +1598,7 @@ class Test_Util(unittest.TestCase):
         if 314 < angle < 316: v=1
         assert v==1
        
-    def test_calc_bearings_zero_vector(self): 
+    def test_calc_bearings_zero_vector(self):
         from math import atan, degrees
 
         uh = 0
@@ -1606,7 +1606,29 @@ class Test_Util(unittest.TestCase):
         angle = calc_bearing(uh, vh)
 
         assert angle == NAN
-        
+
+    def test_get_gauges_from_file(self):
+        """get_gauges_from_file must parse a gauge file.
+
+        Regression test: the helper called ``gauge_get_from_file`` without
+        importing it (that function lives in ``gauge``), so every call raised
+        ``NameError``. It should return the (locations, names, elevations)
+        triple read from the file.
+        """
+        handle, filename = tempfile.mkstemp('.txt')
+        os.close(handle)
+        with open(filename, 'w') as fid:
+            fid.write('easting, northing, name, elevation\n')
+            fid.write('308500, 6193000, gauge_a, 1.0\n')
+            fid.write('308700, 6193200, gauge_b, 2.5\n')
+
+        gauges, gaugelocation, elev = get_gauges_from_file(filename)
+        os.remove(filename)
+
+        assert gauges == [[308500.0, 6193000.0], [308700.0, 6193200.0]]
+        assert gaugelocation == ['gauge_a', 'gauge_b']
+        assert elev == [1.0, 2.5]
+
 #-------------------------------------------------------------
 
 if __name__ == "__main__":

--- a/anuga/abstract_2d_finite_volumes/util.py
+++ b/anuga/abstract_2d_finite_volumes/util.py
@@ -131,6 +131,8 @@ def get_textual_float(value, format = '%.2f'):
             return format % float(value)
 
 def get_gauges_from_file(filename):
+    # Imported locally to avoid a circular import: gauge imports from util.
+    from anuga.abstract_2d_finite_volumes.gauge import gauge_get_from_file
     return gauge_get_from_file(filename)
 
 


### PR DESCRIPTION
## Problem

`anuga.abstract_2d_finite_volumes.util.get_gauges_from_file` raises `NameError` on every call:

```python
def get_gauges_from_file(filename):
    return gauge_get_from_file(filename)
```

`gauge_get_from_file` is defined in `abstract_2d_finite_volumes/gauge.py` (line 540) and is **not imported** into `util.py` (which uses only explicit imports, no `import *`). So any call to `get_gauges_from_file` fails with `NameError: name 'gauge_get_from_file' is not defined`. `pyflakes util.py` flags it as `undefined name 'gauge_get_from_file'`.

## Fix

Import `gauge_get_from_file` **locally inside the function**. A module-level import would be circular: `gauge.py` already does `from .util import check_list, calc_bearing` at module load, so importing `gauge` from the top of `util` would create an import cycle. The function-local import matches the existing convention in this package (e.g. `gauge.plot_gauge_data` imports `util.file_function` inside the function body for the same reason).

## Reproduction & verification

Both functions are pure-Python (they read a CSV gauge file), so the path verifies end-to-end without building the Cython extensions:

```
OLD  -> NameError: name 'gauge_get_from_file' is not defined
FIXED -> ([[308500.0, 6193000.0], [308700.0, 6193200.0]], ['gauge_a', 'gauge_b'], [1.0, 2.5])
```

Added `Test_Util.test_get_gauges_from_file` (writes a small `easting, northing, name, elevation` gauge file and asserts the parsed triple). It fails on `main` (`NameError`) and passes with this change.

`pyflakes` and `pycodestyle` are clean on both changed files. I was unable to run the full suite locally (the `meson-python` editable build failed at metadata generation on macOS, unrelated to this change), so the new test is verified via the standalone reproduction above and will run in CI.

Note: `get_gauges_from_file` currently has no in-tree callers and is a thin wrapper over `gauge_get_from_file`. I've restored it rather than removing it, but if you'd prefer to drop the redundant wrapper instead, happy to do that.